### PR TITLE
Add google ads conversion tracking on successful sign up

### DIFF
--- a/src/components/SignUpForm.astro
+++ b/src/components/SignUpForm.astro
@@ -362,6 +362,35 @@
         }
       }
     });
+
+    // Fire Google Ads conversion
+
+    const successPanel = document.getElementById("success-message");
+    if (!successPanel) return;
+
+    const successfulSignUpObserver = new MutationObserver((mutations) => {
+      for (const mutation of mutations) {
+        if (
+          mutation.type === "attributes" &&
+          mutation.attributeName === "class"
+        ) {
+          const successPanel = mutation.target as HTMLElement;
+          if (
+            successPanel.classList.contains("sib-form-message-panel--active")
+          ) {
+            // @ts-ignore
+            gtag("event", "conversion", {
+              send_to: "AW-640602160/9UVmCKmtu9ABELCgu7EC",
+            });
+          }
+        }
+      }
+    });
+
+    successfulSignUpObserver.observe(successPanel, {
+      attributes: true,
+      attributeFilter: ["class"],
+    });
   })();
 </script>
 


### PR DESCRIPTION
Fire the conversion event when the success message is shown by observing the class addition that makes the message visible, because listening for form submission doesn't work. Brevo's validation would have to be duplicated perfectly. There's no way to hook into Brevo's submit handler, that I can see. So checking when success message is displayed is the most accurate way I could think to fire the conversion event.